### PR TITLE
docs: 添加 Docker 镜像选型指南和示例

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -48,9 +48,9 @@ ENV PATH="/app/.venv/bin:/python/bin:$PATH"
 # 使用 distroless 的非 root 用户
 USER nonroot
 
-# 健康检查
+# 健康检查 (使用 JSON 格式，不依赖 shell)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=2)" || exit 1
+    CMD ["python", "-c", "import httpx; httpx.get('http://localhost:8000/health', timeout=2)"]
 
-# 启动应用
-CMD ["fastapi", "run", "server.py", "--host", "0.0.0.0", "--port", "8000"]
+# 启动应用 (使用 uvicorn 代替 fastapi run，更适合生产环境)
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -48,7 +48,7 @@ USER app
 
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=2)" || exit 1
+    CMD ["python", "-c", "import httpx; httpx.get('http://localhost:8000/health', timeout=2)"]
 
-# 启动应用
-CMD ["fastapi", "run", "server.py", "--host", "0.0.0.0", "--port", "8000"]
+# 启动应用 (使用 uvicorn 代替 fastapi run，更适合生产环境)
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -36,7 +36,7 @@ WORKDIR /app
 # 从构建阶段复制依赖和代码
 COPY --from=builder --chown=app:app /app /app
 
-# 安装运行时依赖（如果需要）
+# 安装运行时依赖（Alpine 需要 libgcc 等运行时库）
 RUN apk add --no-cache \
     libgcc \
     && rm -rf /var/cache/apk/*
@@ -44,5 +44,5 @@ RUN apk add --no-cache \
 # 切换到非 root 用户
 USER app
 
-# 启动应用
-CMD ["fastapi", "run", "server.py", "--host", "0.0.0.0", "--port", "8000"]
+# 启动应用 (使用 uvicorn 代替 fastapi run，更适合生产环境)
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## 概述

此 PR 为容器化 LLM 代理系统添加了 Docker 基础镜像选型指南和示例。

## 变更内容

### 新增文档
- `doc/docker-images.md` - 详细的 Docker 镜像选型指南，包含：
  - Python 3.12 Slim（推荐生产环境）
  - Google Distroless（安全优先）
  - Alpine Linux（不推荐）

### 新增示例文件
- `Dockerfile.example` - 基于 Python 3.12 Slim 的完整示例
- `Dockerfile.distroless` - 基于 Google Distroless 的最小化示例
- `Dockerfile.minimal` - 基于 Alpine 的示例（仅供参考）

## 镜像对比

| 镜像 | 大小 | Python 版本 | 推荐度 |
|------|------|------------|--------|
| `python:3.12-slim-bookworm` | ~118 MB | 3.12.12 | ⭐⭐⭐⭐⭐ |
| `gcr.io/distroless/cc` | ~23 MB | 需单独安装 | ⭐⭐⭐⭐ |
| `gcr.io/distroless/python3` | ~50 MB | 3.11.2 | ⭐⭐⭐ |
| `python:3.12-alpine` | ~60 MB | 3.12.x | ⭐⭐ |

## 技术特点

所有方案都包含：
- ✅ 多阶段构建（减少最终镜像大小）
- ✅ uv 包管理器集成
- ✅ 非 root 用户运行（安全最佳实践）
- ✅ 健康检查配置

## 推荐方案

**生产环境**: 使用 `Dockerfile.example`（Python 3.12 Slim）
- 平衡了大小、兼容性和可调试性
- 官方维护，定期安全更新
- 完整的 glibc 支持

**安全优先**: 使用 `Dockerfile.distroless`（Distroless）
- 最小攻击面
- 无 shell，无法被利用
- 符合最小权限原则

## 测试建议

```bash
# 构建 Python Slim 版本
docker build -f Dockerfile.example -t agent:slim .

# 构建 Distroless 版本
docker build -f Dockerfile.distroless -t agent:distroless .

# 运行测试
docker run -p 8000:8000 agent:slim
```

## 参考资料

- [Python Docker 官方镜像](https://hub.docker.com/_/python)
- [Google Distroless](https://github.com/GoogleContainerTools/distroless)
- [Python on Docker Production Handbook](https://pythonspeed.com/docker/)
- [Building a Python Docker Image with Distroless and Uv](https://www.joshkasuboski.com/posts/distroless-python-uv/)

#20