### PR TITLE
fix(server.py): only include latest review batch in comment trigger

### DIFF
--- a/server.py
+++ b/server.py
@@ -683,13 +683,18 @@ def build_rich_context(
                 if item.type == "review":
                     # 找到最新一次 review（按时间顺序，最后一个是最新）
                     latest_review_id = item.id
-                    reviews_history.append({
-                        "id": item.id,
-                        "user": item.user,
-                        "body": item.body,
-                        "state": item.state,
-                        "submitted_at": item.created_at
-                    })
+
+            # 只添加最新一次 review
+            if latest_review_id:
+                for item in timeline_items:
+                    if item.type == "review" and item.id == latest_review_id:
+                        reviews_history.append({
+                            "id": item.id,
+                            "user": item.user,
+                            "body": item.body,
+                            "state": item.state,
+                            "submitted_at": item.created_at
+                        })
 
             # 只保留与最新 review 相关的 review comments
             if latest_review_id:


### PR DESCRIPTION
## Summary

确保 review 批次（reviews_history 和 review_comments_batch）**不截断，尽量完整保留**，同时在 comment 触发时**只包含最新一次 review 及其相关评论**（最新批次）。

## Changes

修改 `build_rich_context()` 函数：

1. **Review 批次使用原始 `timeline_items`**（不截断）
   - `reviews_history` 和 `review_comments_batch` 现在始终使用原始的 `timeline_items`，确保完整保留所有 review 信息

2. **评论历史仍使用截断后的 `truncated_items`**
   - `comments_history` 继续使用智能截断算法（3新1旧比例）处理，以控制上下文大小

3. **两种触发类型的处理逻辑**：
   - **review/review_comment 触发**：精确过滤，只保留与当前 review 相关的项目（基于 review_id 匹配）
   - **comment 触发**：只包含**最新一次 review**及其相关的 review comments（最新批次），仅评论使用截断

## Behavior

| 触发类型 | comments_history | reviews_history | review_comments_batch |
|---------|------------------|-----------------|----------------------|
| comment | 截断 (3:1) | **最新一次 review** | **最新 review 的 comments** |
| review/review_comment | 不包含 | 精确过滤 (当前review) | 精确过滤 (当前review) |

## 关于"最新批次"的定义

根据需求："最新批次"指最新一次 review 下的所有条目（review 在 GitHub 中可以多条一起提交，为一个批次）。

在 comment 触发时：
- `reviews_history` 只包含最新一次 review
- `review_comments_batch` 只包含与最新 review 相关的 review comments

Fixes requirement: "最新批次"指最新一次review下的所有条目

🤖 Generated with [Claude Code](https://claude.com/claude-code)