### PR TITLE
feat: 在 LLM workflow 中添加 WakaTime 配置步骤

### DIFF
--- a/.github/workflows/llm-bot-runner.yml
+++ b/.github/workflows/llm-bot-runner.yml
@@ -134,6 +134,28 @@ jobs:
         env:
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
 
+      - name: Configure WakaTime
+        run: |
+          # 安装WakaTime插件
+          echo "安装WakaTime插件..."
+          claude plugin marketplace add https://github.com/wakatime/claude-code-wakatime.git
+          claude plugin i claude-code-wakatime@wakatime
+
+          # 配置WakaTime API Key
+          if [ -n "$WAKE_TIME_API_KEY" ]; then
+            echo "配置WakaTime API Key..."
+            mkdir -p ~
+            cat << EOF > ~/.wakatime.cfg
+[settings]
+api_key = $WAKE_TIME_API_KEY
+EOF
+            echo "WakaTime配置完成"
+          else
+            echo "警告: WAKE_TIME_API_KEY未设置，跳过WakaTime配置"
+          fi
+        env:
+          WAKE_TIME_API_KEY: ${{ secrets.WAKE_TIME_API_KEY }}
+
       - name: Pre-configure Git
         run: |
           echo "配置Git用户信息..."


### PR DESCRIPTION
## Summary

在 LLM workflow 的 `llm-bot-runner.yml` 中添加了 WakaTime 配置步骤，用于跟踪 Claude Code 的编码活动。

## Changes

在 `Add MCP servers` 步骤之后新增了 `Configure WakaTime` 步骤：

1. **安装 WakaTime 插件**：
   - 从 GitHub 市场安装 `claude-code-wakatime` 插件
   - 激活插件

2. **配置 WakaTime API Key**：
   - 使用环境变量 `WAKE_TIME_API_KEY`（GitHub Secret）
   - 创建 `~/.wakatime.cfg` 配置文件
   - 如果未设置密钥，则跳过配置并显示警告

## 使用方法

在 GitHub 仓库的 Settings → Secrets and variables → Actions 中添加 `WAKE_TIME_API_KEY` secret，值为 WakaTime 的 API Key。

## 相关 Issue

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)